### PR TITLE
Add ability to ignore default SSH known hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,11 @@ Although you may want to additional one, using the following properties:
           ssh-extra-known-host: "my-awesome-private-git-host.com"
 ```
 
+You can also disable the default hosts (for example, if you are behind a corporate proxy) like so:
+```yaml
+        with:
+          ssh-ignore-default-hosts: true
+```
 
 ### log Timestamp
 

--- a/action.yml
+++ b/action.yml
@@ -31,7 +31,10 @@ inputs:
     description: 'The SSH passphrase'
     required: false
   ssh-extra-known-host:
-    description: 'Addtion SSH known host'
+    description: 'Additional SSH known host'
+    required: false
+  ssh-ignore-default-hosts:
+    description: 'Do not add the default SSH known hosts'
     required: false
 
   git-release-bot-name:
@@ -141,6 +144,7 @@ runs:
     SSH_ROOT_FOLDER: /root/.ssh
     SSH_PASSPHRASE: ${{ inputs.ssh-passphrase }}
     SSH_EXTRA_KNOWN_HOST: ${{ inputs.ssh-extra-known-host }}
+    SSH_IGNORE_DEFAULT_HOSTS: ${{ inputs.ssh-ignore-default-hosts }}
 
     MAVEN_REPO_SERVER_ID: ${{ inputs.maven-repo-server-id }}
     MAVEN_REPO_SERVER_USERNAME: ${{ inputs.maven-repo-server-username }}


### PR DESCRIPTION
Add the ability to ignore the default added known hosts during SSH configuration.
This PR relies on the merge (and build) of https://github.com/qcastel/docker-maven-release/pull/6 

When adding this feature, the action is usable in corporate environments where a proxy is used, or certain external access is blocked.